### PR TITLE
Remove inline from EventLoop.run

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -49,7 +49,6 @@ pub struct EventLoop;
 impl EventLoop {
     #[inline]
     pub fn new() -> EventLoop { EventLoop }
-    #[inline]
     pub fn run(&self) { loop {} }
 }
 


### PR DESCRIPTION
For whatever reason when running `--release`, inlining this method and calling it causes thread panics on osx el capitan running rust 1.16 nightly. Removing the inline attribute masks this for now.